### PR TITLE
Updated alias_template to be W3C compliant (and added backup message to template)

### DIFF
--- a/pageless_redirects.rb
+++ b/pageless_redirects.rb
@@ -135,6 +135,10 @@ module Jekyll
       <meta http-equiv="content-type" content="text/html; charset=utf-8" />
       <meta http-equiv="refresh" content="0; url=#{destination_path}" />
       </head>
+      <body>
+        <p><strong>Redirecting...</strong></p>
+        <p><a href='#{destination_path}'>Click Here</a> if you are not redirected</p>
+      </body>
       </html>
       EOF
     end


### PR DESCRIPTION
Fixed two non-compliance errors with alias_template:
"Bad value 0;url=#{destination_path} for attribute content on element meta: Expected a space character, but saw u instead."
"Element head is missing a required instance of child element title."

Added body to alias_template, in case the user has automatic redirects disabled. It provides a link to the destination.

Fixed source repository url link (it was 404ing)
